### PR TITLE
Making it possible to signout without being logged in, doesn't really…

### DIFF
--- a/Presentation.Web/Controllers/API/AuthorizeController.cs
+++ b/Presentation.Web/Controllers/API/AuthorizeController.cs
@@ -65,6 +65,7 @@ namespace Presentation.Web.Controllers.API
             }
         }
 
+        [AllowAnonymous]
         public HttpResponseMessage PostLogout(bool? logout)
         {
             try

--- a/Presentation.Web/app/services/userServices.ts
+++ b/Presentation.Web/app/services/userServices.ts
@@ -89,9 +89,7 @@
 
         function getUser() {
             var deferred = $q.defer();
-
             deferred.resolve(loadUser(null));
-
             return deferred.promise;
         }
 
@@ -156,24 +154,13 @@
         }
 
         function logout() {
-            var deferred = $q.defer();
+            $window.sessionStorage.removeItem('userResponse');
+            clearSavedOrgId();
+            loadUserDeferred = null;
+            _user = null;
+            $rootScope.user = null;
 
-            $http.post("api/authorize?logout").success(function (result) {
-                loadUserDeferred = null;
-                _user = null;
-                $rootScope.user = null;
-
-                deferred.resolve();
-
-                clearSavedOrgId();
-                $window.sessionStorage.removeItem('userResponse');
-
-            }).error(function (result) {
-                deferred.reject("Could not log out");
-
-            });
-
-            return deferred.promise;
+            return $http.post("api/authorize?logout");
         }
 
         function auth(adminRoles) {


### PR DESCRIPTION
… make sense but it fixes a state where the auth cookie expires and the client still thinks it's logged in.